### PR TITLE
Enable Wercker CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![wercker status](https://app.wercker.com/status/4db748e2b586121e924f83ef991a5f7b/s "wercker status")](https://app.wercker.com/project/bykey/4db748e2b586121e924f83ef991a5f7b)
+[![Coverage Status](https://coveralls.io/repos/github/sensorbee/opencv/badge.svg?branch=master)](https://coveralls.io/github/sensorbee/opencv?branch=master)
+
 # OpenCV plug-in for SensorBee
 
 This plug-in is a library to use [OpenCV](http://opencv.org) library, User can use a part of OpenCV functions. For example user can create source component to generate stream video capturing.

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,22 @@
+box: suma/opencv-dev-sensorbee-go1.6
+build:
+  steps:
+    - wercker/setup-go-workspace
+    - script:
+        name: go version
+        code: |
+          go version
+          sensorbee --version
+    - script:
+        name: Install import packages and build
+        code: |
+          go get -t -d -v ./...
+          go build -v ./...
+    - script:
+        name: Run test
+        code: |
+          gotestcover -v -covermode=count -coverprofile=.profile.cov -parallelpackages=1 ./...
+    - script:
+        name: Coveralls.io
+        code: |
+          goveralls -coverprofile=.profile.cov -service='wercker.com' -repotoken $COVERALLS_TOKEN

--- a/wercker.yml
+++ b/wercker.yml
@@ -8,6 +8,10 @@ build:
           go version
           sensorbee --version
     - script:
+        name: Check code style
+        code: |
+          golint ./...
+    - script:
         name: Install import packages and build
         code: |
           go get -t -d -v ./...


### PR DESCRIPTION
I setuped [Wercker](https://app.wercker.com/project/bykey/4db748e2b586121e924f83ef991a5f7b) and [Coveralls](https://coveralls.io/github/sensorbee/opencv?branch=master) services for opencv plugin.
This PR contains golint check but does not contain go vet.

Wercker helps us to deploy CI environment with image at Docker Hub so we can build and test project quickly. Docker image is based on Ubuntu 14.04 LTS that OpenCV 2.4 and Go 1.6 installed.
In the future, we want to test with Go 1.4 and 1.5 but environment process seems to be very slow with travis. Currently I enabled only to use Go 1.6 with Wercker for this plugin.