### PR TITLE
Remove Coveralls from CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![wercker status](https://app.wercker.com/status/4db748e2b586121e924f83ef991a5f7b/s "wercker status")](https://app.wercker.com/project/bykey/4db748e2b586121e924f83ef991a5f7b)
-[![Coverage Status](https://coveralls.io/repos/github/sensorbee/opencv/badge.svg?branch=master)](https://coveralls.io/github/sensorbee/opencv?branch=master)
 
 # OpenCV plug-in for SensorBee
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -19,8 +19,4 @@ build:
     - script:
         name: Run test
         code: |
-          gotestcover -v -covermode=count -coverprofile=.profile.cov -parallelpackages=1 ./...
-    - script:
-        name: Coveralls.io
-        code: |
-          goveralls -coverprofile=.profile.cov -service='wercker.com' -repotoken $COVERALLS_TOKEN
+          go test -v ./...


### PR DESCRIPTION
We discussed that we may remove coverage report with CI.
This opencv plugin has many uncovered code with unittest.