### PR TITLE
Fix wercker.yml for package directory

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,7 +1,8 @@
 box: suma/opencv-dev-sensorbee-go1.6
 build:
   steps:
-    - wercker/setup-go-workspace
+    - wercker/setup-go-workspace:
+        package-dir: gopkg.in/sensorbee/opencv.v0
     - script:
         name: go version
         code: |


### PR DESCRIPTION
Specify correct package directory path for Wercker.
It is similiar to `go_import_path` of travis-ci.